### PR TITLE
Add test for service with empty upstreams

### DIFF
--- a/test/empty_upstreams_test.bats
+++ b/test/empty_upstreams_test.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+load "common"
+
+
+setup() {
+  etcdctl rm --recursive /kontena/haproxy/lb/services || true
+}
+
+@test "if no upstreams, service frontend retained in config" {
+  etcdctl set /kontena/haproxy/lb/services/service-b/virtual_hosts www.foo.com
+  etcdctl set /kontena/haproxy/lb/services/service-a/virtual_path /
+  etcdctl set /kontena/haproxy/lb/services/service-a/upstreams/server service-a:9292
+
+  sleep 1
+  run curl -sL -w "%{http_code}" -H "Host: www.foo.com" http://localhost:8180/ -o /dev/null
+  [ "${lines[0]}" = "503" ]
+
+  run config
+  assert_output_contains "use_backend service-b" 1
+}


### PR DESCRIPTION
This adds a test for the current behavior of https://github.com/kontena/kontena/issues/1725, that is, without the fix in #26.

IMO the broken upstreams len check is actually a feature, not a bug, as demonstrated in this test case: http://www.foo.com/ will return a HTTP 503 error. With the "fixed" upstream len checks in #26, that request would end up returning a response from the `service-a` backend (with `virtual_path=/`) instead:

```
$ etcdctl ls --recursive -p /kontena
/kontena/haproxy/
/kontena/haproxy/lb_no_health/
/kontena/haproxy/lb_no_health/services/
/kontena/haproxy/lb_no_health/tcp-services/
/kontena/haproxy/lb_no_health/certs/
/kontena/haproxy/lb/
/kontena/haproxy/lb/tcp-services/
/kontena/haproxy/lb/certs/
/kontena/haproxy/lb/certs/bundle
/kontena/haproxy/lb/services/
/kontena/haproxy/lb/services/service-b/
/kontena/haproxy/lb/services/service-b/virtual_hosts
/kontena/haproxy/lb/services/service-a/
/kontena/haproxy/lb/services/service-a/virtual_path
/kontena/haproxy/lb/services/service-a/upstreams/
/kontena/haproxy/lb/services/service-a/upstreams/server
$ etcdctl get /kontena/haproxy/lb/services/service-b/virtual_hosts
www.foo.com
$ etcdctl get /kontena/haproxy/lb/services/service-a/virtual_path
/
```

```
$ curl -H 'Host: www.foo.com' http://localhost:8180
service-a
```